### PR TITLE
feat!: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,20 @@ Multicall for everyone.
 
 
 [dependencies]
-thiserror = "1.0.0"
-
-alloy-sol-types = { version = "0.8.0", features = ["std", "json"] }
-alloy-primitives = "0.8.12"
-alloy-contract = "0.6.4"
-alloy-provider = { version = "0.6.4", features = ["reqwest"] }
-alloy-transport = "0.6.4"
-alloy-chains = "0.1.47"
-alloy-dyn-abi = "0.8.0"
-alloy-json-abi = "0.8.0"
-
+thiserror = "2.0.0"
+alloy = { version = "0.9.2", default-features = false, features = [
+    "contract",
+    "providers",
+    "std",
+] }
+alloy-chains = "0.1.53"
 
 [dev-dependencies]
 tokio = { version = "1.40.0", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+alloy = { version = "0.9.2", default-features = false, features = [
+    "contract",
+    "providers",
+    "reqwest-rustls-tls",
+    "std",
+] }

--- a/examples/get_amount_out.rs
+++ b/examples/get_amount_out.rs
@@ -1,7 +1,10 @@
-use alloy_dyn_abi::DynSolValue;
+use alloy::{
+    dyn_abi::DynSolValue,
+    primitives::{address, U256},
+    sol,
+    sol_types::JsonAbiExt as _,
+};
 use alloy_multicall::Multicall;
-use alloy_primitives::{address, U256};
-use alloy_sol_types::{sol, JsonAbiExt};
 
 sol! {
     #[derive(Debug)]
@@ -19,7 +22,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     let rpc_url = "https://rpc.ankr.com/eth".parse().unwrap();
-    let provider = alloy_provider::ProviderBuilder::new().on_http(rpc_url);
+    let provider = alloy::providers::ProviderBuilder::new().on_http(rpc_url);
     let uniswap_v2 = address!("7a250d5630b4cf539739df2c5dacb4c659f2488d");
 
     let mut multicall = Multicall::with_provider_chain_id(&provider).await.unwrap();

--- a/examples/simple_erc20.rs
+++ b/examples/simple_erc20.rs
@@ -1,8 +1,9 @@
-use alloy_dyn_abi::DynSolValue;
+use alloy::{
+    dyn_abi::DynSolValue,
+    primitives::{address, Bytes},
+    sol,
+};
 use alloy_multicall::Multicall;
-use alloy_primitives::{address, Bytes};
-use alloy_sol_types::sol;
-use std::result::Result as StdResult;
 
 sol! {
     #[derive(Debug, PartialEq)]
@@ -20,7 +21,7 @@ sol! {
 async fn main() {
     tracing_subscriber::fmt::init();
     let rpc_url = "https://rpc.ankr.com/eth".parse().unwrap();
-    let provider = alloy_provider::ProviderBuilder::new().on_http(rpc_url);
+    let provider = alloy::providers::ProviderBuilder::new().on_http(rpc_url);
     let weth_address = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
 
     // Create the multicall instance
@@ -67,7 +68,7 @@ async fn main() {
     assert_results(results);
 }
 
-fn assert_results(results: Vec<StdResult<DynSolValue, Bytes>>) {
+fn assert_results(results: Vec<Result<DynSolValue, Bytes>>) {
     // Get the expected individual results.
     let name = results.get(1).unwrap().as_ref().unwrap().as_str().unwrap();
     let decimals = results

--- a/examples/simple_trc20.rs
+++ b/examples/simple_trc20.rs
@@ -1,8 +1,9 @@
-use alloy_dyn_abi::DynSolValue;
+use alloy::{
+    dyn_abi::DynSolValue,
+    primitives::{address, Bytes},
+    sol,
+};
 use alloy_multicall::Multicall;
-use alloy_primitives::{address, Bytes};
-use alloy_sol_types::sol;
-use std::result::Result as StdResult;
 
 sol! {
     #[derive(Debug, PartialEq)]
@@ -19,8 +20,8 @@ sol! {
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
-    let rpc_url = "https://rpc.ankr.com/tron_jsonrpc".parse().unwrap();
-    let provider = alloy_provider::ProviderBuilder::new().on_http(rpc_url);
+    let rpc_url = "https://api.trongrid.io/jsonrpc".parse().unwrap();
+    let provider = alloy::providers::ProviderBuilder::new().on_http(rpc_url);
     // Tron use base58 encoded, below is hex encoded value of `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`
     let usdc_contract_addr = address!("a614f803B6FD780986A42c78Ec9c7f77e6DeD13C");
 
@@ -77,7 +78,7 @@ async fn main() {
     assert_results(results);
 }
 
-fn assert_results(results: Vec<StdResult<DynSolValue, Bytes>>) {
+fn assert_results(results: Vec<Result<DynSolValue, Bytes>>) {
     // Get the expected individual results.
     let name = results.get(1).unwrap().as_ref().unwrap().as_str().unwrap();
     let decimals = results

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,6 +1,5 @@
 #![allow(missing_docs)]
-
-use alloy_sol_types::sol;
+use alloy::sol;
 
 sol! {
   #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,3 @@
-use alloy_contract::Error as ContractError;
-use alloy_transport::TransportError;
-
 /// Errors when interacting with a Multicall contract.
 #[derive(Debug, thiserror::Error)]
 pub enum MulticallError {
@@ -10,11 +7,11 @@ pub enum MulticallError {
 
     /// An error occurred interacting with a contract over RPC.
     #[error(transparent)]
-    TransportError(#[from] TransportError),
+    TransportError(#[from] alloy::transports::TransportError),
 
     /// Error when interacting with contracts. This is an error from the `contract` crate.
     #[error(transparent)]
-    ContractError(#[from] ContractError),
+    ContractError(#[from] alloy::contract::Error),
 
     /// Multicall reverted due to an individual call failing.
     #[error("Multicall call reverted but `allowFailure` is false")]

--- a/src/multicall_address.rs
+++ b/src/multicall_address.rs
@@ -1,5 +1,5 @@
+use alloy::primitives::{address, Address};
 use alloy_chains::NamedChain;
-use alloy_primitives::{address, Address};
 
 /// The Multicall3 contract address that is deployed to each [`MULTICALL_SUPPORTED_CHAINS`]:
 /// [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://etherscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11)
@@ -43,8 +43,8 @@ pub const MULTICALL_ADDRESS_DEFAULT_CHAINS: &[u64] = {
         64240,                           // Fantom Sonic
         BinanceSmartChain as u64,        // BNB Smart Chain
         BinanceSmartChainTestnet as u64, // BNB Smart Chain Testnet
-        5611,                            // opBNB Testnet
-        204,                             // opBNB
+        OpBNBTestnet as u64,             // opBNB Testnet
+        OpBNBMainnet as u64,             // opBNB
         Moonbeam as u64,                 // Moonbeam
         Moonriver as u64,                // Moonriver
         Moonbase as u64,                 // Moonbase Alpha Testnet
@@ -54,10 +54,10 @@ pub const MULTICALL_ADDRESS_DEFAULT_CHAINS: &[u64] = {
         Cronos as u64,                   // Cronos
         CronosTestnet as u64,            // Cronos Testnet
         122,                             // Fuse
-        14,                              // Flare Mainnet
+        Flare as u64,                    // Flare Mainnet
         19,                              // Songbird Canary Network
         16,                              // Coston Testnet
-        114,                             // Coston2 Testnet
+        FlareCoston2 as u64,             // Coston2 Testnet
         Boba as u64,                     // Boba
         Aurora as u64,                   // Aurora
         592,                             // Astar
@@ -88,10 +88,10 @@ pub const MULTICALL_ADDRESS_DEFAULT_CHAINS: &[u64] = {
         1234,                            // Step Network
         Canto as u64,                    // Canto
         CantoTestnet as u64,             // Canto Testnet
-        4689,                            // Iotex
+        Iotex as u64,                    // Iotex
         32520,                           // Bitgert
         2222,                            // Kava
-        5003,                            // Mantle Sepolia
+        MantleSepolia as u64,            // Mantle Sepolia
         MantleTestnet as u64,            // Mantle Testnet
         Mantle as u64,                   // Mantle
         8082,                            // Shardeum Sphinx


### PR DESCRIPTION
I'm trying to use this project with the latest version of alloy, but since this crate uses `alloy-provider` v0.6 and I'm using `alloy` v0.9, I have an error because the types/traits are incompatible. Since those are two different major versions, cargo includes both in the project and the types/traits cannot be reconciled.

This PR updates the package to use the latest version of alloy and removes unnecessary feature flags.

Note: I had to fix a test (block gas limit is > 30M) and an example (trc20 because of dead RPC). 

BREAKING CHANGE: since the major version of the alloy crate(s) has changed, this is a breaking change