### PR TITLE
feat!: update to alloy 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-multicall"
-version = "0.9.2"
+version = "0.11.0"
 authors = ["Corn3333"]
 license = "MIT"
 edition = "2021"
@@ -14,7 +14,7 @@ Multicall for everyone.
 
 [dependencies]
 thiserror = "2.0.0"
-alloy = { version = "0.9.2", default-features = false, features = [
+alloy = { version = "0.11.0", default-features = false, features = [
     "contract",
     "providers",
     "std",
@@ -24,7 +24,7 @@ alloy-chains = "0.1.53"
 [dev-dependencies]
 tokio = { version = "1.40.0", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-alloy = { version = "0.9.2", default-features = false, features = [
+alloy = { version = "0.11.0", default-features = false, features = [
     "contract",
     "providers",
     "reqwest-rustls-tls",

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,10 +1,7 @@
 use std::{marker::PhantomData, result::Result as StdResult};
 
 use alloy::{
-    contract::{
-        private::{Network, Transport},
-        CallBuilder, CallDecoder,
-    },
+    contract::{private::Network, CallBuilder, CallDecoder},
     dyn_abi::{DynSolValue, JsonAbiExt as _},
     json_abi::Function,
     primitives::{Address, Bytes, U256},
@@ -109,25 +106,23 @@ impl MulticallVersion {
 
 #[derive(Debug, Clone)]
 #[must_use = "Multicall does nothing unless you use `call`"]
-pub struct Multicall<T, P, N>
+pub struct Multicall<P, N>
 where
     N: Network,
-    T: Transport + Clone,
-    P: Provider<T, N> + Clone,
+    P: Provider<N> + Clone,
 {
     /// The internal calls vector
     calls: Vec<Call>,
     /// The Multicall3 contract
-    contract: IMulticall3Instance<T, P, N>,
+    contract: IMulticall3Instance<(), P, N>,
     /// The Multicall version to use. The default is 3.
     version: MulticallVersion,
 }
 
-impl<T, P, N> Multicall<T, P, N>
+impl<P, N> Multicall<P, N>
 where
     N: Network,
-    T: Transport + Clone,
-    P: Provider<T, N> + Clone,
+    P: Provider<N> + Clone,
 {
     /// Create a new [Multicall] instance from the given provider and known multicall address.
     ///
@@ -477,7 +472,7 @@ where
     ///
     /// # Returns
     /// Returns a [CallBuilder], which uses [IMulticall3::aggregateCall] for decoding.
-    pub fn as_aggregate(&self) -> CallBuilder<T, &P, PhantomData<IMulticall3::aggregateCall>, N> {
+    pub fn as_aggregate(&self) -> CallBuilder<(), &P, PhantomData<IMulticall3::aggregateCall>, N> {
         let calls = self
             .calls
             .clone()
@@ -499,7 +494,7 @@ where
     /// Returns a [CallBuilder], which uses [IMulticall3::tryAggregateCall] for decoding.
     pub fn as_try_aggregate(
         &self,
-    ) -> CallBuilder<T, &P, PhantomData<IMulticall3::tryAggregateCall>, N> {
+    ) -> CallBuilder<(), &P, PhantomData<IMulticall3::tryAggregateCall>, N> {
         let mut allow_failure = true;
 
         let calls = self
@@ -533,7 +528,7 @@ where
     /// Returns a [CallBuilder], which uses [IMulticall3::aggregate3Call] for decoding.
     pub fn as_aggregate_3(
         &self,
-    ) -> CallBuilder<T, &P, PhantomData<IMulticall3::aggregate3Call>, N> {
+    ) -> CallBuilder<(), &P, PhantomData<IMulticall3::aggregate3Call>, N> {
         let calls = self
             .calls
             .clone()
@@ -760,10 +755,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(chain_id, 1); // Provider forked from Mainnet should always have chain ID 1
-        assert!(
-            (29_900_000..=30_200_000).contains(&gas_limit),
-            "{gas_limit}"
-        ); // Mainnet gas limit is approx 30m
+        assert!(gas_limit > 29_900_000, "{gas_limit}"); // Mainnet gas limit is approx 30m, often more
         assert!((306_276..=306_277).contains(&eth_balance)); // Parity multisig bug affected wallet
                                                              // - balance isn't expected to change
                                                              // significantly


### PR DESCRIPTION
This is a breaking change because of the new major alloy version in the dependencies, but the interface did not change. There is one less generic parameter in the struct (because they type-erased the transport) so maybe breaking? Anyway I guess it's a good idea to keep the same version as alloy.